### PR TITLE
Step11 pessimistic lock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/concert/reservation/application/payment/PaymentFacade.java
+++ b/src/main/java/com/concert/reservation/application/payment/PaymentFacade.java
@@ -7,19 +7,19 @@ import com.concert.reservation.domain.payment.PaymentStatus;
 import com.concert.reservation.domain.reservation.ReservationDomain;
 import com.concert.reservation.domain.reservation.ReservationService;
 import com.concert.reservation.domain.reservation.ReservationStatus;
-import com.concert.reservation.domain.seat.SeatOptionService;
 import com.concert.reservation.domain.token.TokenService;
 import com.concert.reservation.domain.token.TokenStatus;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PaymentFacade {
 
     private final TokenService tokenService;
-    private final SeatOptionService seatOptionService;
     private final ReservationService reservationService;
     private final CustomerService customerService;
     private final PaymentService paymentService;
@@ -37,26 +37,27 @@ public class PaymentFacade {
      */
     @Transactional
     public PaymentDomain payment(Long customerId, Long concertOptionId, Long seatOptionId, Long amount) {
-        // 토큰 유효성 체크
-        tokenService.checkActiveStatus(customerId);
-
-        // 잔액 유효성 체크
-        customerService.checkAmount(customerId, amount);
+        log.info("Thread : {} start", Thread.currentThread().getName());
 
         // 예약 조회
         ReservationDomain reservationDomain = reservationService.findByConcertOptionIdAndSeatOptionIdAndCustomerId(concertOptionId, seatOptionId, customerId);
+        // 예약 상태 값 변경 (미완료 → 완료)
+        reservationService.changeStatus(reservationDomain.getReservationId(), ReservationStatus.COMPLETE);
+
+        // 잔액 유효성 체크
+        customerService.checkAmount(customerId, amount);
+        // 이용자 금액 사용
+        customerService.useAmount(customerId, amount);
+
+        // 토큰 상태 값 변경 (활성화 → 만료)
+        tokenService.changeStatus(customerId, TokenStatus.EXPIRE);
 
         // 결제
         PaymentDomain paymentDomain = paymentService.save(PaymentDomain.builder().reservationId(reservationDomain.getReservationId()).amount(amount).status(PaymentStatus.COMPLETE).build());
 
-        // 이용자 금액 사용
-        customerService.useAmount(customerId, amount);
+        log.info("[{}] 가 결제 완료", Thread.currentThread().getName());
 
-        // 예약 상태 값 변경 (미완료 → 완료)
-        reservationService.changeStatus(reservationDomain.getReservationId(), ReservationStatus.COMPLETE);
-
-        // 토큰 상태 값 변경 (활성화 → 만료)
-        tokenService.changeStatus(customerId, TokenStatus.EXPIRE);
+        log.info("Thread : {} end", Thread.currentThread().getName());
 
         return paymentDomain;
     }

--- a/src/main/java/com/concert/reservation/application/reservation/ReservationFacade.java
+++ b/src/main/java/com/concert/reservation/application/reservation/ReservationFacade.java
@@ -8,8 +8,10 @@ import com.concert.reservation.domain.seat.SeatOptionStatus;
 import com.concert.reservation.domain.token.TokenService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ReservationFacade {
@@ -30,6 +32,8 @@ public class ReservationFacade {
      */
     @Transactional
     public ReservationDomain reservationConcert(Long customerId, Long concertOptionId, Long seatOptionId) {
+        log.info("Thread : {} start", Thread.currentThread().getName());
+
         // 좌석 유효성 체크
         seatOptionService.checkAvailableStatus(seatOptionId, concertOptionId);
 
@@ -37,6 +41,12 @@ public class ReservationFacade {
         seatOptionService.changeStatus(seatOptionId, concertOptionId, SeatOptionStatus.UNAVAILABLE);
 
         // 예약 (미완료)
-        return reservationService.save(ReservationDomain.builder().customerId(customerId).concertOptionId(concertOptionId).seatOptionId(seatOptionId).status(ReservationStatus.INCOMPLETE).build());
+        ReservationDomain reservationDomain = reservationService.save(customerId, concertOptionId, seatOptionId, ReservationStatus.INCOMPLETE);
+
+        log.info("[" + Thread.currentThread().getName() + "] 가 예약 완료");
+
+        log.info("Thread : {} end", Thread.currentThread().getName());
+
+        return reservationDomain;
     }
 }

--- a/src/main/java/com/concert/reservation/domain/reservation/ReservationRepository.java
+++ b/src/main/java/com/concert/reservation/domain/reservation/ReservationRepository.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 public interface ReservationRepository {
     ReservationDomain findByReservationId(Long reservationId);
     ReservationDomain findByConcertOptionIdAndSeatOptionIdAndCustomerId(Long concertOptionId, Long seatOptionId, Long customerId);
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<ReservationDomain> findByConcertOptionIdAndSeatOptionIdAndCustomerIdNotException(Long concertOptionId, Long seatOptionId, Long customerId);
     List<ReservationDomain> findAllIncompleteReservationsByCustomerIdAndReservationDt(Long customerId, LocalDateTime reservationDt);
     ReservationDomain save(ReservationDomain reservationDomain);

--- a/src/main/java/com/concert/reservation/domain/reservation/ReservationRepository.java
+++ b/src/main/java/com/concert/reservation/domain/reservation/ReservationRepository.java
@@ -1,5 +1,7 @@
 package com.concert.reservation.domain.reservation;
 
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -10,6 +12,7 @@ import java.util.Optional;
 public interface ReservationRepository {
     ReservationDomain findByReservationId(Long reservationId);
     ReservationDomain findByConcertOptionIdAndSeatOptionIdAndCustomerId(Long concertOptionId, Long seatOptionId, Long customerId);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<ReservationDomain> findByConcertOptionIdAndSeatOptionIdAndCustomerIdNotException(Long concertOptionId, Long seatOptionId, Long customerId);
     List<ReservationDomain> findAllIncompleteReservationsByCustomerIdAndReservationDt(Long customerId, LocalDateTime reservationDt);
     ReservationDomain save(ReservationDomain reservationDomain);

--- a/src/main/java/com/concert/reservation/domain/seat/SeatOptionService.java
+++ b/src/main/java/com/concert/reservation/domain/seat/SeatOptionService.java
@@ -2,6 +2,7 @@ package com.concert.reservation.domain.seat;
 
 import com.concert.reservation.domain.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
@@ -9,6 +10,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SeatOptionService {
@@ -59,7 +61,7 @@ public class SeatOptionService {
     public void changeStatus(Long seatOptionId, Long concertOptionId, SeatOptionStatus status) {
         // 좌석 조회
         SeatOptionDomain seatOptionDomain = this.findSeat(seatOptionId, concertOptionId);
-        
+
         // 가능
         if (SeatOptionStatus.AVAILABLE.equals(status)) {
             seatOptionDomain.changeStatusToAvailable();

--- a/src/main/java/com/concert/reservation/infrastructure/reservation/ReservationJpaRepository.java
+++ b/src/main/java/com/concert/reservation/infrastructure/reservation/ReservationJpaRepository.java
@@ -1,7 +1,9 @@
 package com.concert.reservation.infrastructure.reservation;
 
 import com.concert.reservation.domain.reservation.entity.Reservation;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -13,6 +15,7 @@ import java.util.Optional;
 @Repository
 public interface ReservationJpaRepository extends JpaRepository<Reservation, Long> {
     Optional<Reservation> findByReservationId(Long reservationId);
+    @Lock(LockModeType.PESSIMISTIC_READ)
     Optional<Reservation> findByConcertOptionIdAndSeatOptionIdAndCustomerId(Long concertOptionId, Long seatOptionId, Long customerId);
 
     // 특정 고객의 미완료 상태의 예약 조회

--- a/src/main/java/com/concert/reservation/infrastructure/seat/SeatOptionJpaRepository.java
+++ b/src/main/java/com/concert/reservation/infrastructure/seat/SeatOptionJpaRepository.java
@@ -19,7 +19,7 @@ public interface SeatOptionJpaRepository extends JpaRepository<SeatOption, Long>
                    "     , status" +
                    "  FROM seat_option" +
                    " WHERE seat_option_id = :seat_option_id" +
-                   "   AND concert_option_id = :concert_option_id", nativeQuery = true)
+                   "   AND concert_option_id = :concert_option_id FOR UPDATE", nativeQuery = true)
     SeatOption findSeat(@Param("seat_option_id") Long seatOptionId, @Param("concert_option_id") Long concertOptionId);
 
     // 예약 가능 좌석 조회

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
         format_sql: true      # 쿼리 로그 포맷 (정렬)
-        show_sql: true        # 쿼리 로그 출력
+        show_sql: false        # 쿼리 로그 출력
 
 springdoc:
   packages-to-scan: com.concert.reservation.presentation

--- a/src/test/java/com/concert/reservation/application/payment/PaymentFacadeTest.java
+++ b/src/test/java/com/concert/reservation/application/payment/PaymentFacadeTest.java
@@ -8,14 +8,22 @@ import com.concert.reservation.domain.exception.CustomException;
 import com.concert.reservation.domain.payment.PaymentDomain;
 import com.concert.reservation.domain.token.TokenService;
 import com.concert.reservation.domain.token.TokenStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@Slf4j
 @SpringBootTest
 class PaymentFacadeTest {
     @Autowired
@@ -36,15 +44,18 @@ class PaymentFacadeTest {
     private static final Long seatOptionId2 = 52L;
     private static final Long seatAmount = 100000L;
 
-    @Test
-    @DisplayName("결제 잔액이 충분한 경우")
-    void payment_whenAmountIsEnough() {
-        // given
+    @BeforeEach
+    void setInit() {
         customerService.save(CustomerDomain.builder().customerName("홍길동").amount(15000L).build());
         tokenService.issueToken(customerId1);
         tokenService.changeStatus(customerId1, TokenStatus.ACTIVE);
         reservationFacade.reservationConcert(customerId1, concertOptionId, seatOptionId1);
+    }
 
+    @Test
+    @DisplayName("결제 잔액이 충분한 경우")
+    void payment_whenAmountIsEnough() {
+        // given
         Long amount = customerFacade.findById(customerId1).getAmount();
         Long addMount = 100000L;
         Long totalAmount = amount + addMount;
@@ -62,15 +73,38 @@ class PaymentFacadeTest {
     @Test
     @DisplayName("결제 잔액이 충분하지 않은 경우")
     void payment_whenAmountIsNotEnough() {
-        // given
-        customerService.save(CustomerDomain.builder().customerName("길동무").amount(15000L).build());
-        tokenService.issueToken(customerId2);
-        tokenService.changeStatus(customerId2, TokenStatus.ACTIVE);
-        reservationFacade.reservationConcert(customerId2, concertOptionId, seatOptionId2);
-
         // when-then
         assertThatThrownBy(() -> {
             paymentFacade.payment(customerId2, concertOptionId, seatOptionId2, seatAmount);
         }).isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    @DisplayName("결제 (비관적락 적용)")
+    void paymentWithPessimisticLock() throws InterruptedException {
+        // given
+        Long addMount = 100000L;
+        customerFacade.chargeAmount(customerId1, addMount);
+
+        int threadCount = 10;
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        log.info("Start Time : {}", LocalDateTime.now());
+
+        for (int idx = 0; idx < threadCount; idx++) {
+            executorService.submit(() -> {
+                try {
+                    PaymentDomain paymentDomain = paymentFacade.payment(customerId1, concertOptionId, seatOptionId1, seatAmount);
+                }
+                finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        log.info("End Time : {}", LocalDateTime.now());
     }
 }

--- a/src/test/java/com/concert/reservation/application/reservation/ReservationFacadeTest.java
+++ b/src/test/java/com/concert/reservation/application/reservation/ReservationFacadeTest.java
@@ -62,6 +62,6 @@ class ReservationFacadeTest {
 
         latch.await();
 
-        log.info("End Time : {}", LocalDateTime.now() + "\n\n\n");
+        log.info("End Time : {}", LocalDateTime.now());
     }
 }

--- a/src/test/java/com/concert/reservation/application/reservation/ReservationFacadeTest.java
+++ b/src/test/java/com/concert/reservation/application/reservation/ReservationFacadeTest.java
@@ -1,13 +1,20 @@
 package com.concert.reservation.application.reservation;
 
 import com.concert.reservation.domain.reservation.ReservationDomain;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Slf4j
 @SpringBootTest
 class ReservationFacadeTest {
 
@@ -27,5 +34,34 @@ class ReservationFacadeTest {
 
         // then
         assertThat(reservationDomain).isNotNull();
+    }
+
+    @Test
+    @DisplayName("콘서트 좌석 예약 요청 (비관적락 적용)")
+    void reservationConcertWithPessimisticLock() throws InterruptedException {
+        Long customerId = 1L;
+        Long concertOptionId = 2L;
+        Long seatOptionId = 51L;
+
+        int threadCount = 10;
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        log.info("Start Time : {}", LocalDateTime.now());
+
+        for (int idx = 0; idx < threadCount; idx++) {
+            executorService.submit(() -> {
+                try {
+                    ReservationDomain reservationDomain = reservationFacade.reservationConcert(customerId, concertOptionId, seatOptionId);
+                }
+                finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        log.info("End Time : {}", LocalDateTime.now() + "\n\n\n");
     }
 }


### PR DESCRIPTION
안녕하세요. 코치님
낙관적락에서 Jpa 캐시 초기화(?), 로직 동작 시 트랜잭션 신규생성(?) 부분에 대해서 정확하게 구현하는 방법을 잘 모르겠습니다.. 
Q1. 조회 시 version 값이 항상 같은 값으로 출력이 되는데 캐시 초기화가 정확히 동작하지 않아서 그런 걸까요??
Q2. Retry가 무한정 발생하게 되는데 끝이 도달하게 리밋 관련 부분을 구현을 따로 해야 하는 건가요?? 실제 현업에서는 어떤 식으로 활용하는지도 궁금합니다.!
[낙관적락 PR](https://github.com/iPhone-design/hhplus-concert-reservation-java/pull/30)


현재 PR은 비관적락을 적용하여 반영한 상태 입니다.!